### PR TITLE
Allow empty tests for submission only usecases.

### DIFF
--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -201,9 +201,6 @@ class Assignment(core.Serializable):
 
                 log.info('Loaded {}'.format(test_name))
 
-        if not self.test_map:
-            raise ex.LoadingException('No tests loaded')
-
     def dump_tests(self):
         """Dumps all tests, as determined by their .dump() method.
 


### PR DESCRIPTION
The use case for this patch to use ok-client to submit homework but not using okpy to perform any tests. It is still a well-formed `.ok` configuration even when there are no tests -- so ok-client shall not die when we do not perform tests on an empty set of tests.

The condition is used again later, when tests are 'resolved'. I think that shall be converted to a warning, but since we do not use any tests yet I cannot comment to much on that one.