### PR TITLE
Parameterize client secret

### DIFF
--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -20,7 +20,10 @@ log = logging.getLogger(__name__)
 CLIENT_ID = 'ok-client'
 # The client secret in an installed application isn't a secret.
 # See: https://developers.google.com/accounts/docs/OAuth2InstalledApp
-CLIENT_SECRET = 'EWKtcCp5nICeYgVyCPypjs3aLORqQ3H'
+# However, for other authentication providers such as Azure Active Directory
+# this might not be the case
+CLIENT_SECRET = os.getenv('OK_CLIENT_SECRET',
+                          'EWKtcCp5nICeYgVyCPypjs3aLORqQ3H')
 OAUTH_SCOPE = 'all'
 
 REFRESH_FILE = os.path.join(CONFIG_DIRECTORY, "auth_refresh")


### PR DESCRIPTION
This issue was found by @taupalosaurus. If a non-Google authentication provider is used, the client secret stored in the OKpy database will be different from this hard-coded value which causes the ok-client to ok-server communication to fail.

A work-around for this is to manually adjust the client secret in the ok-server database via the following command.

```sql
UPDATE client
SET client_secret='EWKtcCp5nICeYgVyCPypjs3aLORqQ3H'
WHERE client_id='ok-client';
```

However, a more long-term manageable fix is to parameterize the client secret and set it to the correct value for the authentication provider in each ok-client deployment.
