### PR TITLE
Add code to support JupyterLab saving

### DIFF
--- a/client/api/notebook.py
+++ b/client/api/notebook.py
@@ -92,8 +92,7 @@ class Notebook:
             return
 
         if mode not in ['jupyter', 'jupyterlab']:
-            print("Invalid save mode. Use either \'jupyter\' or \'jupyterlab\'", end=' ')
-            return
+            print("Invalid save mode. Use either \'jupyter\' or \'jupyterlab\'")
 
         if mode == "jupyter":
             display(Javascript('IPython.notebook.save_checkpoint();'))


### PR DESCRIPTION
Fixes #359. 

Previously, JupyterLab's removal of the IPython object in JavaScript affected our ability to call ok.submit() in code. The solution is to directly trigger the frontend save button's click() method with the following snippet: `document.querySelector('[data-command="docmanager:save"]').click();`.

I've also added code to allow selection of each mode via a parameter (default is normal Jupyter Notebook). The reason this isn't done in code is it's difficult to determine reliably which frontend an IPython kernel is running inside.