### PR TITLE
Improved clarity for submission error when wrong file is saved

### DIFF
--- a/client/api/notebook.py
+++ b/client/api/notebook.py
@@ -104,7 +104,7 @@ class Notebook:
                 print("Saved '{}'.".format(ipynbs[0]))
             else:
                 log.warning("Timed out waiting for IPython save")
-                print("Could not automatically save {}")
+                print("Could not automatically save \'{}\'".format(ipynbs[0]))
                 print("Make sure your notebook"
                       " is correctly named and saved before submitting to OK!".format(ipynbs[0]))
                 return False                

--- a/client/api/notebook.py
+++ b/client/api/notebook.py
@@ -62,11 +62,19 @@ class Notebook:
     def submit(self):
         messages = {}
         self.assignment.set_args(submit=True)
-        self.save(messages)
-        return self.run('backup', messages)
-
+        if self.save(messages):
+            return self.run('backup', messages)
+        else:
+            filename = self.assignment.src[0]
+            print("Making a best attempt to submit latest \'{}\',"
+                " last modified at {}".format(filename, time.ctime(os.path.getmtime(filename))))
+            return self.run('backup', messages)
+        
     def save(self, messages, delay=0.5, attempts=3):
-        self.save_notebook()
+        saved = self.save_notebook()
+        if not saved:
+            return None
+
         for _ in range(attempts):
             self.run('file_contents', messages)
             if validate_contents(messages['file_contents']):
@@ -87,7 +95,7 @@ class Notebook:
 
         display(Javascript('IPython.notebook.save_checkpoint();'))
         display(Javascript('IPython.notebook.save_notebook();'))
-        print('Saving notebook...', end=' ')
+        print('Saving notebook...')
         ipynbs = [path for path in self.assignment.src
                   if os.path.splitext(path)[1] == '.ipynb']
         # Wait for first .ipynb to save
@@ -96,10 +104,13 @@ class Notebook:
                 print("Saved '{}'.".format(ipynbs[0]))
             else:
                 log.warning("Timed out waiting for IPython save")
-                print("Could not save your notebook. Make sure your notebook"
-                      " is saved before sending it to OK!")
+                print("Could not automatically save {}")
+                print("Make sure your notebook"
+                      " is correctly named and saved before submitting to OK!".format(ipynbs[0]))
+                return False                
         else:
-            print()
+            print("No valid file sources found")
+        return True
 
 def login_with_env(assignment):
     access_token = os.environ.get('OKPY_ACCESS_TOKEN')


### PR DESCRIPTION
Fixes #352 

Clarification of issue: users working on a different file from the one specified in config get cryptic error messages during ok.submit(), and the wrong file is submitted (the case where the file in config doesn't exist throws an error).

Detecting the current notebook name in Jupyter is difficult/unreliable. Instead, this PR provides a more descriptive error message and warns the user that the current submission may not be the current file they are working on. The ok client still attempts to submit the file that is specified in the configuration (as the submit method should). 

