### PR TITLE
include newer versions of coverage in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     ],
     install_requires=[
         'requests==2.12.4',
-        'coverage==3.7.1'
+        'coverage>=3.7.1'
     ],
 )


### PR DESCRIPTION
Some students were reporting difficulties installing this with pip. They were getting error messages like 
`ERROR: okpy 1.14.15 has requirement coverage==3.7.1, but you’ll have coverage 4.5.3 which is incompatible.`