### PR TITLE
Add quick smoke test

### DIFF
--- a/tests/end_to_end/smoke_test.py
+++ b/tests/end_to_end/smoke_test.py
@@ -5,7 +5,24 @@ import subprocess
 
 class SmokeTest(unittest.TestCase):
 
-    def testRuns(self):
-        with tempfile.TemporaryDirectory() as f:
-            publish.package_client(f)
-            subprocess.check_call(['python', 'ok', '--version'], cwd=f, stdout=None)
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory().name
+        publish.package_client(self.directory)
+
+    def run_ok(self, *args):
+        proc = subprocess.Popen(
+            ['python', 'ok', *args],
+            cwd=self.directory,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        return proc.stdout.read().decode("utf-8"), proc.stderr.read().decode("utf-8")
+
+    def testVersion(self):
+        stdout, stderr = self.run_ok("--version")
+        self.assertRegex(stdout, "^okpy==.*")
+        self.assertEqual(stderr, "")
+
+    def testUpdate(self):
+        stdout, stderr = self.run_ok("--update")
+        self.assertRegex(stdout, "Current version: v[0-9.]+\nChecking for software updates...\nOK is up to date")
+        self.assertEqual(stderr, "")

--- a/tests/end_to_end/smoke_test.py
+++ b/tests/end_to_end/smoke_test.py
@@ -1,0 +1,12 @@
+from client.utils import output
+import sys
+import unittest
+import tempfile
+import subprocess
+
+class SmokeTest(unittest.TestCase):
+
+    def testRuns(self):
+        with tempfile.TemporaryDirectory() as f:
+            subprocess.check_call(['ok-publish', "-d", f])
+            subprocess.check_call(['python', 'ok'], cwd=f)

--- a/tests/end_to_end/smoke_test.py
+++ b/tests/end_to_end/smoke_test.py
@@ -1,5 +1,4 @@
-from client.utils import output
-import sys
+from client.cli import publish
 import unittest
 import tempfile
 import subprocess
@@ -8,5 +7,5 @@ class SmokeTest(unittest.TestCase):
 
     def testRuns(self):
         with tempfile.TemporaryDirectory() as f:
-            subprocess.check_call(['ok-publish', "-d", f])
-            subprocess.check_call(['python', 'ok'], cwd=f)
+            publish.package_client(f)
+            subprocess.check_call(['python', 'ok', '--version'], cwd=f, stdout=None)


### PR DESCRIPTION
This successfully catches issues like the cacert.pem issue that happens when we upgrade requests