### PR TITLE
Fix output encoding mismatch

### DIFF
--- a/client/utils/output.py
+++ b/client/utils/output.py
@@ -1,5 +1,6 @@
 """This module contains code related to controlling and writing to stdout."""
 
+import io
 import os
 import sys
 
@@ -9,7 +10,7 @@ class _OutputLogger(object):
 
     def __init__(self, stdout=sys.stdout):
         self._current_stream = self._stdout = stdout
-        self._devnull = open(os.devnull, 'w')
+        self._devnull = io.open(os.devnull, 'w', encoding=getattr(stdout, 'encoding', 'utf-8'))
         self._logs = {}
         self._num_logs = 0
 


### PR DESCRIPTION
Outputting Unicode on Windows can result in an error since the default encoding for `open()` (`cp1252`) can be different from that of stdio. Here we make it match that of the underlying stream.

For earlier Python versions it would also be necessary to change the default encoding for stdio to `utf-8`, but I avoided doing that here since the default appears to have been already changed to UTF-8 as of Python 3.7(?).