### PR TITLE
Fix: refresh the refresh_token

### DIFF
--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -124,7 +124,7 @@ def make_refresh_post(server, refresh_token):
         'refresh_token': refresh_token,
     }
     info = make_token_post(server, data)
-    return info['access_token'], int(info['expires_in'])
+    return info['access_token'], int(info['expires_in']), info['refresh_token']
 
 def get_storage():
     create_config_directory()
@@ -157,7 +157,7 @@ def refresh_local_token(server):
     access_token, expires_at, refresh_token = get_storage()
     if cur_time < expires_at - 10:
         return access_token
-    access_token, expires_in = make_refresh_post(server, refresh_token)
+    access_token, expires_in, refresh_token = make_refresh_post(server, refresh_token)
     if not (access_token and expires_in):
         raise AuthenticationException(
             "Authentication failed and returned an empty token.")


### PR DESCRIPTION
Currently, `ok-client` doesn't acknowledge the fact that the `refresh_token` changes when used. This means that after the first automatic token refresh, a subsequent refresh will require manual approval (since the token will be incorrect). This PR should fix this issue.