### PR TITLE
Add multiline=True flag to unlockable cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       if: startsWith(runner.os, 'windows')
       with:
         path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: v2-${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: ${{ runner.os }}-pip-
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -103,6 +103,7 @@ jobs:
           *       ) scripts="bin";;
         esac
         . "${VENV_DIR}/${scripts}/activate"
+        python -m pip install --upgrade pip
         python -m pip install --default-timeout=1000 -r requirements.txt
     - name: Run tests
       shell: bash

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -87,7 +87,8 @@ class UnlockProtocol(models.Protocol):
                 break
         messages['unlock'] = self.analytics
 
-    def interact(self, unique_id, case_id, question_prompt, answer, choices=None, randomize=True, *, normalizer=lambda x: x):
+    def interact(self, unique_id, case_id, question_prompt, answer, choices=None, randomize=True,
+                 *, multiline=False, normalizer=lambda x: x):
         """Reads student input for unlocking tests until the student
         answers correctly.
 
@@ -133,7 +134,7 @@ class UnlockProtocol(models.Protocol):
             input_lines = []
 
             for line_number, line in enumerate(answer):
-                if len(answer) == 1:
+                if len(answer) == 1 and not multiline:
                     prompt = self.PROMPT
                 else:
                     prompt = '(line {}){}'.format(line_number + 1, self.PROMPT)

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -81,7 +81,10 @@ class CodeCase(models.Case):
                     line.output = interact(unique_id,
                                            case_id + ' >  Prompt {}'.format(prompt_num),
                                            '\n'.join(current_prompt),
-                                           line.output, normalizer=self.console.normalize, choices=line.choices)
+                                           line.output,
+                                           normalizer=self.console.normalize,
+                                           choices=line.choices,
+                                           multiline=self.multiline)
                     line.locked = False
                     current_prompt = []
             self.locked = False

--- a/client/sources/common/models.py
+++ b/client/sources/common/models.py
@@ -36,6 +36,7 @@ class Case(core.Serializable):
 
     hidden = core.Boolean(default=False)
     locked = core.Boolean(optional=True)
+    multiline = core.Boolean(optional=True)
 
     def run(self):
         """Subclasses should override this method for running a test case.


### PR DESCRIPTION
Lets you add a `multiline=True` flag to cases. When this flag is present, the unlock protocol will always use the multiline protocol. This is needed when we have a question where multiline answers are _possible_, but the correct answer has just one line. Otherwise, students can look at the prompt to determine whether the answer has just one or multiple lines.

Test plan: `pytest testForceMultipleLineMultipleFailsBeforeSuccess`.