### PR TITLE
Remove 3.5 support to CI, add 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         name: [
+          Python 3.9 (Windows),
+          Python 3.9 (Macintosh),
+          Python 3.9 (Ubuntu),
           Python 3.8 (Windows),
           Python 3.8 (Macintosh),
           Python 3.8 (Ubuntu),
@@ -19,9 +22,6 @@ jobs:
           Python 3.6 (Windows),
           Python 3.6 (Macintosh),
           Python 3.6 (Ubuntu),
-          Python 3.5 (Windows),
-          Python 3.5 (Macintosh),
-          Python 3.5 (Ubuntu),
         ]
         include:
           - name: Python 3.8 (Windows)


### PR DESCRIPTION
Python 3.6 adds f-strings which are now both used in OKClient and in CS61A assignments, and are generally super awesome. Cs61A currently recommends installing Python 3.9 so it seems safe to upgrade minimum version to 3.6.