### PR TITLE
Remove 3.5 support from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
             os: windows-latest
             python-version: 3.6
           - name: Python 3.6 (Macintosh)
-            os: macos-latest
+            os: macOS-10.15
             python-version: 3.6
           - name: Python 3.6 (Ubuntu)
             os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         name: [
+          Python 3.9 (Windows),
+          Python 3.9 (Macintosh),
+          Python 3.9 (Ubuntu),
           Python 3.8 (Windows),
           Python 3.8 (Macintosh),
           Python 3.8 (Ubuntu),
@@ -19,11 +22,17 @@ jobs:
           Python 3.6 (Windows),
           Python 3.6 (Macintosh),
           Python 3.6 (Ubuntu),
-          Python 3.5 (Windows),
-          Python 3.5 (Macintosh),
-          Python 3.5 (Ubuntu),
         ]
         include:
+          - name: Python 3.9 (Windows)
+            os: windows-latest
+            python-version: 3.9
+          - name: Python 3.9 (Macintosh)
+            os: macos-latest
+            python-version: 3.9
+          - name: Python 3.9 (Ubuntu)
+            os: ubuntu-latest
+            python-version: 3.9
           - name: Python 3.8 (Windows)
             os: windows-latest
             python-version: 3.8
@@ -51,15 +60,6 @@ jobs:
           - name: Python 3.6 (Ubuntu)
             os: ubuntu-latest
             python-version: 3.6
-          - name: Python 3.5 (Windows)
-            os: windows-latest
-            python-version: 3.5
-          - name: Python 3.5 (Macintosh)
-            os: macos-latest
-            python-version: 3.5
-          - name: Python 3.5 (Ubuntu)
-            os: ubuntu-latest
-            python-version: 3.5
     env:
       VENV_DIR: env
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         name: [
-          Python 3.9 (Windows),
-          Python 3.9 (Macintosh),
-          Python 3.9 (Ubuntu),
           Python 3.8 (Windows),
           Python 3.8 (Macintosh),
           Python 3.8 (Ubuntu),
@@ -24,15 +21,6 @@ jobs:
           Python 3.6 (Ubuntu),
         ]
         include:
-          - name: Python 3.9 (Windows)
-            os: windows-latest
-            python-version: 3.9
-          - name: Python 3.9 (Macintosh)
-            os: macos-latest
-            python-version: 3.9
-          - name: Python 3.9 (Ubuntu)
-            os: ubuntu-latest
-            python-version: 3.9
           - name: Python 3.8 (Windows)
             os: windows-latest
             python-version: 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ filelock==3.0.12
 lark==0.12.0
 
 # Tests
-nose==1.3.7
+nose==1.3.3
 pylint==1.2.1
 mock==1.0.1
 virtualenv==16.7.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ filelock==3.0.12
 lark==0.12.0
 
 # Tests
-nose==1.3.3
+nose==1.3.7
 pylint==1.2.1
 mock==1.0.1
 virtualenv==16.7.9


### PR DESCRIPTION
Python 3.6 adds f-strings which are now both used in OKClient and in CS61A assignments, and are generally super awesome. Cs61A currently recommends installing Python 3.9 so it seems safe to upgrade minimum version to 3.6.