### PR TITLE
Rename fpp to parsons

### DIFF
--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -72,7 +72,7 @@ class Assignment(core.Serializable):
     default_tests = core.List(type=str, optional=True)
     # ignored, for backwards-compatibility only
     protocols = core.List(type=str, optional=True)
-    fpp = core.Dict(keys=str, values=dict, optional=True)
+    parsons = core.Dict(keys=str, values=dict, optional=True)
 
     ####################
     # Programmatic API #
@@ -427,21 +427,21 @@ class Assignment(core.Serializable):
         """Verifies that all desired parsons problems exist and that the 
         structure of parsons is proper.
         """
-        if self.fpp is core.NoValue:
+        if self.parsons is core.NoValue:
             return
         log.info('Loading parsons problems')
-        for prob_group_name, v in self.fpp.items():
+        for prob_group_name, v in self.parsons.items():
             req_probs = v.get('required', []) 
             opt_probs = v.get('optional', []) 
             if 'required' not in v and 'optional' not in v:
-                error_message = 'Need a "required" and/or "optional" key in an fpp config object'
+                error_message = 'Need a "required" and/or "optional" key in a parsons config object'
                 raise ex.LoadingException(error_message)
             if not isinstance(req_probs, list) or not isinstance(opt_probs, list): 
-                error_message = 'The "required" and "optional" keys, if included in an fpp config object, must be lists'
+                error_message = 'The "required" and "optional" keys, if included in a parsons config object, must be lists'
                 raise ex.LoadingException(error_message)
             for prob in (req_probs + opt_probs):
                 if prob not in self.test_map:
-                    error_message = f'Problem name "{prob}" in the fpp problem group "{prob_group_name}" is invalid' 
+                    error_message = f'Problem name "{prob}" in the parsons problem group "{prob_group_name}" is invalid' 
                     raise ex.LoadingException(error_message)
 
     def _print_header(self):

--- a/client/cli/lock.py
+++ b/client/cli/lock.py
@@ -32,7 +32,7 @@ def main():
     args.verbose = False
     args.interactive = False
     args.ignore_empty = False
-    args.fpp = False
+    args.parsons = False
 
     try:
         assign = assignment.load_assignment(args.config, args)

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -189,7 +189,7 @@ def parse_input(command_input=None):
     server.add_argument('--update', action='store_true',
                         help="update ok and exit")
     # used in faded-parsons-frontend repo
-    server.add_argument('--fpp', action='store_true', 
+    server.add_argument('--parsons', action='store_true', 
                         help="run faded parsons problems in browser")  
 
     return parser.parse_args(command_input)

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -190,7 +190,7 @@ def parse_input(command_input=None):
                         help="update ok and exit")
     # used in faded-parsons-frontend repo
     server.add_argument('--parsons', action='store_true', 
-                        help="run faded parsons problems in browser")  
+                        help="run parsons problems in browser")  
 
     return parser.parse_args(command_input)
 

--- a/client/protocols/analytics.py
+++ b/client/protocols/analytics.py
@@ -48,7 +48,7 @@ class AnalyticsProtocol(models.Protocol):
             if self.args.case:
                 statistics['requested-case'] = self.args.case
 
-        if self.args.fpp:
+        if self.args.parsons:
             statistics['action'] = messages.get('action', '')
 
         messages['analytics'] = statistics

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -34,8 +34,8 @@ class CodeCase(models.Case):
         self.setup = setup
         self.teardown = teardown
 
-        # must reload for fpp problems
-        if self.setup and self.console.fpp:
+        # must reload for parsons problems
+        if self.setup and self.console.parsons:
             assignment_name = self.setup.split()[2]
             self.setup = textwrap.dedent(self.setup)
             self.setup += f"\n>>> import {assignment_name}"
@@ -200,11 +200,11 @@ class Console(object):
     # Public interface #
     ####################
 
-    def __init__(self, verbose, interactive, timeout=None, fpp=False):
+    def __init__(self, verbose, interactive, timeout=None, parsons=False):
         self.verbose = verbose
         self.interactive = interactive
         self.timeout = timeout
-        self.fpp = fpp
+        self.parsons = parsons
         self.skip_locked_cases = True
         self.load('')   # Initialize empty code.
 
@@ -235,7 +235,7 @@ class Console(object):
         RETURNS:
         bool; True if the code passes, False otherwise.
         """
-        if not self._interpret_lines(self._setup, should_print=not self.fpp):
+        if not self._interpret_lines(self._setup, should_print=not self.parsons):
             return False
 
         success = self._interpret_lines(self._code, compare_all=True)

--- a/client/sources/common/pyconsole.py
+++ b/client/sources/common/pyconsole.py
@@ -15,9 +15,9 @@ class PythonConsole(interpreter.Console):
     PS1 = '>>> '
     PS2 = '... '
 
-    def __init__(self, verbose, interactive, timeout=None, fpp=False):
+    def __init__(self, verbose, interactive, timeout=None, parsons=False):
         self._original_frame = {}
-        super().__init__(verbose, interactive, timeout, fpp)
+        super().__init__(verbose, interactive, timeout, parsons)
 
     def load(self, code, setup='', teardown=''):
         """Prepares a set of setup, test, and teardown code to be

--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -74,7 +74,7 @@ def _load_test(file, module, name, assign):
     docstring = func.__doc__ if func.__doc__ else ''
     try:
         return models.Doctest(file, assign.cmd_args.verbose, assign.cmd_args.interactive,
-                              assign.cmd_args.timeout, assign.cmd_args.ignore_empty, assign.cmd_args.fpp,
+                              assign.cmd_args.timeout, assign.cmd_args.ignore_empty, assign.cmd_args.parsons,
                               name=name, points=1, docstring=docstring)
     except ex.SerializeException:
         raise ex.LoadingException('Unable to load doctest for {} '

--- a/client/sources/doctest/models.py
+++ b/client/sources/doctest/models.py
@@ -23,7 +23,7 @@ class Doctest(models.Test):
     SETUP = PS1 + IMPORT_STRING
     prompt_re = re.compile(r'(\s*)({}|{})'.format(PS1, '\.\.\. '))
 
-    def __init__(self, file, verbose, interactive, timeout=None, ignore_empty=False, fpp=False, **fields):
+    def __init__(self, file, verbose, interactive, timeout=None, ignore_empty=False, parsons=False, **fields):
         super().__init__(**fields)
         self.file = file
         self.verbose = verbose
@@ -32,7 +32,7 @@ class Doctest(models.Test):
         self.ignore_empty = ignore_empty
 
         self.console = pyconsole.PythonConsole(self.verbose, self.interactive,
-                                                  self.timeout, fpp)
+                                                  self.timeout, parsons)
 
     def post_instantiation(self):
         # TODO(albert): rewrite test validation. Inconsistent leading space is

--- a/tests/sources/common/interpreter_test.py
+++ b/tests/sources/common/interpreter_test.py
@@ -10,7 +10,7 @@ class CodeCaseTest(unittest.TestCase):
         self.console.PS1 = '> '
         self.console.PS2 = '. '
         self.console.normalize = lambda x: x
-        self.console.fpp = False
+        self.console.parsons = False
 
     def makeCase(self, code, setup='', teardown=''):
         return interpreter.CodeCase(self.console, setup, teardown, code=code)


### PR DESCRIPTION
Sorry that we went back and forth on this, but we realized that FPP is an acronym that only our own group uses, while "Parsons Problems" (or "Faded Parsons") are what everyone else recognizes. So this PR rids the OSS world of one more unnecessary obscure acronym.

I realize this affects multiple PRs in the cs61a repo and I will check them out with this change next. (After watching the results of this CI test).