### PR TITLE
Don't use emojis

### DIFF
--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -6,8 +6,6 @@ from client.utils import locking, format
 import re
 import textwrap
 
-CHECK_MARK = ":D"
-RED_X = ":("
 
 class CodeCase(models.Case):
     """TestCase for doctest-style Python tests."""
@@ -345,13 +343,13 @@ class Console(object):
                 raise ConsoleException
             elif self.CASE_PREFIX in code:
                 self.cases_total += 1
-                print(RED_X, f"Test Case {self.cases_total} failed")
+                print(":(", f"Test Case {self.cases_total} failed")
                 format.print_line('-')
                 print()
         elif correct and self.CASE_PREFIX in code:
             self.cases_passed += 1
             self.cases_total += 1
-            print(CHECK_MARK, f"Test Case {self.cases_total} passed")
+            print(":D", f"Test Case {self.cases_total} passed")
             format.print_line('-')
             print()
 

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -6,8 +6,8 @@ from client.utils import locking, format
 import re
 import textwrap
 
-CHECK_MARK = "✅"
-RED_X = "❌"
+CHECK_MARK = ":D"
+RED_X = ":("
 
 class CodeCase(models.Case):
     """TestCase for doctest-style Python tests."""


### PR DESCRIPTION
Emojis seem to be causing issues on some machines, so this PR replaces them with simple emoticons instead. A change already made in faded-parsons replaces the emoticons in the Parsons runner with the emojis.

Terminal output:
<img width="473" alt="Screen Shot 2022-01-20 at 10 46 48 PM" src="https://user-images.githubusercontent.com/297042/150480599-d2c3885c-6f4a-43b1-b075-147385b7a969.png">

Parsons runner:
<img width="913" alt="Screen Shot 2022-01-20 at 10 46 29 PM" src="https://user-images.githubusercontent.com/297042/150480605-00615498-cc3e-4216-af4b-82a0682ce968.png">
