### PR TITLE
Fix: always increment total case count

### DIFF
--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -333,7 +333,6 @@ class Console(object):
             and expected.output_lines() == actual.output_lines())
         correct_legacy_exception = (actual.exception
             and [actual.exception_type] == expected.output_lines())
-
         if not correct and not correct_legacy_exception:
             print()
             print('# Error: expected')

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -320,6 +320,7 @@ class Console(object):
             output = printed.splitlines()
             actual = CodeAnswer(output=output)
 
+        self.cases_total += 1
         if not self.skip_locked_cases and expected.locked:
             if '\n'.join(expected.output) != locking.lock(self.hash_key, actual.dump()):
                 print()
@@ -332,6 +333,7 @@ class Console(object):
             and expected.output_lines() == actual.output_lines())
         correct_legacy_exception = (actual.exception
             and [actual.exception_type] == expected.output_lines())
+
         if not correct and not correct_legacy_exception:
             print()
             print('# Error: expected')
@@ -344,16 +346,15 @@ class Console(object):
             if not self.show_all_cases or (actual.exception and actual.exception_type == exceptions.Timeout.__name__):
                 raise ConsoleException
             elif self.CASE_PREFIX in code:
-                self.cases_total += 1
                 print(":(", f"Test Case {self.cases_total} failed")
                 format.print_line('-')
                 print()
-        elif correct and self.CASE_PREFIX in code:
+        elif correct:
             self.cases_passed += 1
-            self.cases_total += 1
-            print(":D", f"Test Case {self.cases_total} passed")
-            format.print_line('-')
-            print()
+            if self.CASE_PREFIX in code:
+                print(":D", f"Test Case {self.cases_total} passed")
+                format.print_line('-')
+                print()
 
     def _strip_prompt(self, line):
         if line.startswith(self.PS1):

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -18,8 +18,8 @@ class PythonConsoleTest(unittest.TestCase):
         return pyconsole.PythonConsole(
                 verbose, interactive, timeout)
 
-    def calls_interpret(self, success, code, setup='', teardown='', skip_locked_cases=True, hash_key=None):
-        self.console = self.createConsole()
+    def calls_interpret(self, success, code, setup='', teardown='', skip_locked_cases=True, hash_key=None, timeout=None):
+        self.console = self.createConsole(timeout=timeout)
         self.console.skip_locked_cases = skip_locked_cases
         self.console.hash_key = hash_key
         lines = interpreter.CodeCase.split_code(code, self.console.PS1,
@@ -334,3 +334,39 @@ class PythonConsoleTest(unittest.TestCase):
         %s
         # locked
         """ % hashedAnswer)
+
+
+    def testPassCount_allPassed(self):
+        code="""
+        >>> 2 + 3
+        5
+        >>> 4 + 6
+        10
+        """[1:]
+        self.calls_interpret(success=True, code=code)
+        self.assertEqual(self.console.cases_passed, 2)
+        self.assertEqual(self.console.cases_total, 2)
+    
+    def testPassCount_withFail(self):
+        code="""
+        >>> 2 + 3
+        5
+        >>> 1 + 3
+        10
+        """[1:]
+        self.calls_interpret(success=False, code=code)
+        self.assertEqual(self.console.cases_passed, 1)
+        self.assertEqual(self.console.cases_total, 2)
+    
+    def testPassCount_timeout(self):
+        code="""
+        >>> 2 + 3
+        5
+        >>> while True: pass
+        10
+        >>> 1 + 3
+        4
+        """[1:]
+        self.calls_interpret(success=False, code=code, timeout=0.5)
+        self.assertEqual(self.console.cases_passed, 1)
+        self.assertEqual(self.console.cases_total, 2)

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -337,6 +337,7 @@ class PythonConsoleTest(unittest.TestCase):
 
 
     def testPassCount_allPassed(self):
+        # remove newline from the front because otherwise it counts as a separate test case
         code="""
         >>> 2 + 3
         5


### PR DESCRIPTION
earlier, when we had an infinite loop, we would not increment the total case count. As a result, when a student timed out on the second test case, the parsons tool would receive {passed: 1, total: 1} and incorrectly display that all test cases passed.