### PR TITLE
show backup url whenever a backup is made

### DIFF
--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -87,7 +87,7 @@ class BackupProtocol(models.Protocol):
                                   submission_type,
                                   response['data']['key'])
 
-            if self.args.submit or self.args.backup:
+            if self.args.submit or self.args.backup or action == "backup":
                 print_success('URL: {0}'.format(url))
 
             if self.args.backup:


### PR DESCRIPTION
Previously, the backup URL only showed when students ran `python3 ok --submit` or `python3 ok --backup`. Per #467, we should show the URL when any backup is made (such as when running `python3 ok`! IMO this is good, but can adjust the wording to something similar to #467 if @pamelafox prefers.

This is what it looks like:
```
=====================================================================
Assignment: Homework 1
OK, version v1.18.1
=====================================================================

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Running tests

---------------------------------------------------------------------
Question 2 > Suite 2 > Case 1

>>> from hw1 import *
>>> double(3)
3

# Error: expected
#     6
# but got
#     3

Run only this test case with "python3 ok -q q2 --suite 2 --case 1"
---------------------------------------------------------------------
Test summary
    1 test cases passed before encountering first failed test case

Backup... 100% complete
Backup past deadline by 1615 days, 40 minutes, and 16 seconds
Backup successful for user: akshit@berkeley.edu
URL: https://okpy.org/ok/test/su16/ex/backups/4919lx

OK is up to date
```