### PR TITLE
Dont recurse on self/im_self

### DIFF
--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -51,7 +51,11 @@ def _load_tests(file, module, assign):
     def _load_tests_from_obj(obj, attribute_path):
         for attr in dir(obj):
             to_test = getattr(obj, attr)
-            if callable(to_test) and getattr(to_test, '__module__', None) == module.__name__:
+            if (
+                callable(to_test)
+                and getattr(to_test, "__module__", None) == module.__name__
+                and attr not in ["__self__", "im_self"]
+            ):
                 path = attribute_path + [attr]
                 name = '.'.join(path)
                 tests[name] = _load_test(file, module, name, assign)


### PR DESCRIPTION
Class decorators are currently causing recursion errors due to the load_tests recursive logic, and the fact that a bound method refers back to the original class in both the self and im_self attributes.
This adds a condition to ignore those attributes.

Example problematic code before:

```
class RandomCat:
    """
    Returns a new instance of a Cat with the given owner,
    a randomly chosen name and a random number of lives.
    >>> randcat = RandomCat.adopt_random_cat("Ifeoma")
    >>> isinstance(randcat, RandomCat)
    True
    >>> randcat.owner
    'Ifeoma'
    """
    cat_names = ["felix", "bugs", "grumpy"]

    def __init__(self, name, owner, lives=9):
        self.is_alive = True
        self.name = name
        self.owner = owner
        self.lives = lives

    @classmethod
    def adopt_random_cat(cls, owner):
        # BEGIN SOLUTION NO PROMPT ALT="___________________________"
        cat_name = RandomCat.cat_names[len(owner) % len(RandomCat.cat_names)]
        num_lives = len(cat_name) + len(owner_name)
        # END SOLUTION
        # BEGIN SOLUTION NO PROMPT ALT="return cls(____, ____, ____)"
        return cls(cat_name, owner, num_lives)
        # END SOLUTION
```