### PR TITLE
Remove transitive dependencies and update requirements

### DIFF
--- a/client/cli/publish.py
+++ b/client/cli/publish.py
@@ -12,7 +12,7 @@ OK_ROOT = os.path.normpath(os.path.dirname(client.__file__))
 CONFIG_NAME = 'config.ok'
 
 EXTRA_PACKAGES = [
-    'requests', 'certifi', 'urllib3', 'chardet', 'idna', # requests/certifi and recursive deps
+    'requests', 'certifi', 'urllib3', 'idna', # requests/certifi and recursive deps
     'coverage', # coverage and recursive deps
     'pytutor', 'ast_scope', 'attr', # pytutor and recursive deps
     'pyaes',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 requests[security]==2.31.0
 certifi==2019.11.28
 urllib3==1.26.17
-chardet==3.0.4
 idna==2.8
 ## Setup
 setuptools==68.2.2

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'requests==2.31.0',
         'certifi==2019.11.28',
         'urllib3==1.26.17',
-        'chardet==3.0.4',
         'idna==2.8',
         'coverage==7.3.2',
         'pytutor==1.0.0',


### PR DESCRIPTION
As part of our ongoing research on Python dependency management, we identified that your project explicitly declares the dependency `chardet`, which is not directly used in the codebase but is installed transitively by higher-level packages such as `okpy`.

Keeping `chardet` in `requirements.txt` or `setup.py` unnecessarily locks its version and increases the risk of dependency conflicts, especially during upgrades. This cleanup removes `chardet` as a top-level requirement to let the resolver handle it based on the needs of the actual top-level packages.

This change aligns with the best practices recommended in the [pip documentation](https://pip.pypa.io/en/stable/topics/dependency-resolution/#audit-your-top-level-requirements), which encourages pruning unused or transitive dependencies to maintain a clean and maintainable dependency graph.
