### PR TITLE
fix: NoValue does not return False when using its boolean value

### DIFF
--- a/client/sources/common/core.py
+++ b/client/sources/common/core.py
@@ -6,7 +6,8 @@ import collections
 ###############
 
 class NoValue(object):
-    pass
+    def __bool__(self):
+        return False
 
 NoValue = NoValue()
 


### PR DESCRIPTION
The bug is already declared in detail in my recently-opened issue saying that the ConceptCase cannot run without choices.